### PR TITLE
feat(BE): sidebar- Public Rooms Logic

### DIFF
--- a/controllers/sidebarController.js
+++ b/controllers/sidebarController.js
@@ -7,38 +7,30 @@ const catchAsync = require('../utils/catchAsync');
 
 exports.readSidebar = catchAsync(async (req, res) => {
   const joined_rooms = [];
+  const public_rooms = [];
   const details = [];
 
-  const { user: user_id, org:organization_id} = req.query;
+  const { user: user_id } = req.query;
 
-  const findUserRooms = await find('roomusers', { user_id }, organization_id);
+  const findUserRooms = await find('roomusers', { user_id });
 
   const { data: userRooms } = findUserRooms.data;
-
-  // if user does not have a room, return an error.
-
 
   if (userRooms.length < 1) {
     return res.status(404).send({ message: `User ${user_id} has not joined any room` });
   }
 
-  // collate all ids of rooms the user has joined
-
   const userRoomIds = userRooms.map((room) => {
     return room.room_id;
   });
 
-  // get all the rooms in the goals plugin
-
-  const getAllrooms = await find('rooms', {organization_id}, organization_id);
+  const getAllrooms = await findAll('rooms');
 
   const { data: allRoomsArr } = getAllrooms.data;
 
-  // get all the room users in the goals plugin
-  const findRoomUsers = await findAll('roomusers', organization_id);
+  const findRoomUsers = await findAll('roomusers');
   const { data: roomUsersArr } = findRoomUsers.data;
 
-  // run a loop to find and populate the details of the room ids the user entered into
   for (let i = 0; i < allRoomsArr.length; i++) {
     for (const roomId of userRoomIds) {
       if (allRoomsArr[i].id === roomId) {
@@ -47,10 +39,20 @@ exports.readSidebar = catchAsync(async (req, res) => {
     }
   }
 
-  // filter the room ids the user entered into and check the number of users attached to the
-  // room id. Also loop through each user's room details to get the room title, id etc
   for (const detail of details) {
     const numOfUsers = roomUsersArr.filter((room) => room.room_id === detail.id).length;
+
+    if (!detail.private) {
+      public_rooms.push({
+        title: detail.title,
+        id: detail.id,
+        unread: 0,
+        members: numOfUsers,
+        icon: 'cdn.cloudflare.com/445345453345/hello.jpeg',
+        action: 'open',
+      });
+    }
+
     joined_rooms.push({
       title: detail.title,
       id: detail.id,
@@ -61,19 +63,17 @@ exports.readSidebar = catchAsync(async (req, res) => {
     });
   }
 
-  // set up the response object
-
   const response = {
     name: 'Company Goals Plugin',
     description: 'Shows company goals items',
     plugin_id: '61330fcfbfba0a42d7f38e59',
-    organisation_id: organization_id,
+    organisation_id: '1',
     user_id,
     group_name: 'Goals',
     show_group: false,
     joined_rooms,
+    public_rooms,
   };
 
-  // return the response.
   return res.status(200).json(response);
 });

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -2,16 +2,17 @@ const Joi = require('joi');
 
 // room schema
 exports.roomSchema = Joi.object({
-    id:Joi.string().required().messages({
-        'any.required':'uuid of the room is required'
-    }),
-    title:Joi.string().required().messages({
-        'any.required':'title of the room is required'
-    }),
-    organization_id:Joi.string().required().messages({
-        'any.required':'organization id is required'
-    }),
-})
+  id: Joi.string().required().messages({
+    'any.required': 'uuid of the room is required',
+  }),
+  title: Joi.string().required().messages({
+    'any.required': 'title of the room is required',
+  }),
+  organization_id: Joi.string().required().messages({
+    'any.required': 'organization id is required',
+  }),
+  isPrivate: Joi.boolean().optional()
+});
 
 // user schema
 exports.userSchema = Joi.object({


### PR DESCRIPTION
Hi, so i created a field in the "create rooms" schema called "isPrivate". I assumed that by default, all room are public when created unless toggled private or created as private rooms directly, hence why i added the isPrivate field to the room creation schema. From there, i created two private rooms and added user with the id of 002 to those two private rooms. From there, i wrote a logic that pushes the rooms with !private (meaning private being false) to the public_rooms array. Meanwhile, joined_rooms has the rooms the user joined irrespective of each room being private or not. 

You can test the sidebar endpoint for user 002 on your local machine by -> localhost:4000/api/v1/sidebar?user=002&org=1 

Hopefully when the auth middleware is completed, the sidebar route protection will be implemented.
![screencapture-localhost-4000-api-v1-sidebar-2021-09-11-11_02_44](https://user-images.githubusercontent.com/54279085/132944206-c23330f8-a467-4a6a-960f-601477233d1e.png)
 