### PR TITLE
edit vision API functionality

### DIFF
--- a/client/src/components/organization_vision/org_edit_vision/modal/EditOrgVisionModal.jsx
+++ b/client/src/components/organization_vision/org_edit_vision/modal/EditOrgVisionModal.jsx
@@ -17,16 +17,13 @@ import {
 const OrganizationVisionEditModal = () => {
   const dispatch = useDispatch();
   const showVisionModal = useSelector(({ organizationVision }) => organizationVision.showVisionModal);
+  const vision = useSelector(({ organizationVision }) => organizationVision.vision);
+  const loading = useSelector(({ organizationVision }) => organizationVision.loading);
   const [editText, setEditText] = useState('');
 
   const dispatchAction = () => {
     if (editText) {
-      dispatch(updateOrgVision(editText))
-        .then(unwrapResult)
-        .then(() => {
-          // console.log('unwrap', data);
-          dispatch(showEditVisionModal());
-        });
+      dispatch(updateOrgVision(editText));
     }
   };
 
@@ -46,10 +43,17 @@ const OrganizationVisionEditModal = () => {
           <Header id="transition-modal-title">Edit Vision</Header>
           <TextBox placeholder="Click to edit..." value={editText} onChange={(e) => setEditText(e.target.value)} />
           <ActionButtonsContainer>
-            <ActionCancelEditVisionButton onClick={() => dispatch(showEditVisionModal())}>
+            <ActionCancelEditVisionButton disabled={loading} onClick={() => dispatch(showEditVisionModal())}>
               Cancel
             </ActionCancelEditVisionButton>
-            <ActionButton onClick={dispatchAction}>Save</ActionButton>
+            <ActionButton
+              disabled={loading}
+              onClick={() => {
+                dispatchAction();
+              }}
+            >
+              {loading ? 'please wait' : 'save'}
+            </ActionButton>
           </ActionButtonsContainer>
         </EditVisionContainer>
       </Fade>

--- a/client/src/redux/organizationVision.slice.js
+++ b/client/src/redux/organizationVision.slice.js
@@ -3,7 +3,10 @@ import axios from 'axios';
 
 export const updateOrgVision = createAsyncThunk('editVision/updateOrgVisionStatus', async (visionText) => {
   console.log(visionText);
-  const response = await axios.post('/api/vision', { visionText });
+  const token =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb29raWUiOiJNVFl6TVRrNU1qVTBOM3hIZDNkQlIwUlplRTVFVW10UFJFWm9UbXBKTWs5RWFHdFpWRlY2VFVSS2FGa3lUWHBOZHowOWZOZy16Q2wwclFtTjlVdXA1Tm5NNDk2U0V4Tk1IR1lrVUJOZE9YWVo4MDU2IiwiZW1haWwiOiJjcmVhdG9yQGdvYWxzLmNvbSIsImlkIjoiNjE0NGQ4MWE2MjY4OGRhNTMwMmFjYzMzIiwib3B0aW9ucyI6eyJQYXRoIjoiLyIsIkRvbWFpbiI6IiIsIk1heEFnZSI6NjMwNzIwMDAwMCwiU2VjdXJlIjpmYWxzZSwiSHR0cE9ubHkiOmZhbHNlLCJTYW1lU2l0ZSI6MH0sInNlc3Npb25fbmFtZSI6ImY2ODIyYWY5NGUyOWJhMTEyYmUzMTBkM2FmNDVkNWM3In0.Rj8b8Kqnv8xcJ9Nugv8t-hdMV-VlYPHqLYwp9xwtZ7M';
+  const organizationId = '6145d099285e4a184020742e';
+  const response = await axios.patch('/api/v1/vision/1/?token=admin', { vision: visionText }, { authorization: token });
   return response.data;
 });
 
@@ -12,6 +15,7 @@ export const editVisionSlice = createSlice({
   initialState: {
     showVisionModal: false,
     vision: null,
+    loading: false,
   },
   reducers: {
     showEditVisionModal: (state) => {
@@ -25,10 +29,26 @@ export const editVisionSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(updateOrgVision.fulfilled, (state, { payload }) => {
       console.log('success-edit-vison', payload);
+
+      state.vision = payload.update;
+      state.showVisionModal = !state.showVisionModal;
+      state.loading = false;
+      return state;
+    });
+    builder.addCase(updateOrgVision.rejected, (state, action) => {
+      console.log('Error!!!', action);
+      alert(action.error.message);
+      state.loading = false;
+      return state;
+    });
+    builder.addCase(updateOrgVision.pending, (state, action) => {
+      console.log('loading...', action);
+      state.loading = true;
+      return state;
     });
   },
 });
 
-export const { showEditVisionModal, saveVision } = editVisionSlice.actions;
+export const { showEditVisionModal, saveVision, extraReducers } = editVisionSlice.actions;
 
 export default editVisionSlice.reducer;


### PR DESCRIPTION
This PR enables the user

- [x]  to upload the edited vision to the server and update the same edited server on the UI.
- [x] to ensure that only authorized users can edit the company vision