### PR TITLE
Make edit mission and vision modals have same design

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -84,7 +84,7 @@
     "eslint-config-react-important-stuff": "^3.0.0",
     "eslint-plugin-prettier": "^3.4.1",
     "html-webpack-plugin": "^5.3.2",
-    "husky": "^7.0.2",
+    "husky": "7.0.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.0.6",
     "jest-cli": "^27.0.6",

--- a/client/src/components/Modal/styledEditMission.js
+++ b/client/src/components/Modal/styledEditMission.js
@@ -29,7 +29,7 @@ export const SaveBtn = styled.button`
   border: none;
   background-color: rgba(0, 184, 124, 1);
   color: white;
-  padding: 15px 30px;
+  padding: 8px 45.5px;
   border-radius: 6px;
   cursor: pointer;
   float: right;
@@ -53,11 +53,10 @@ export const ModalBody = styled.div`
 export const Paper = styled.div`
   background-color: #f6f6f6;
   border: none;
-  border-radius: 5px;
+  border-radius: 0px;
   padding: 35px;
   font-family: Lato;
   width: 720px;
-  height: 430px;
   max-width: 100%;
   margin: 1rem;
   box-sizing: border-box;

--- a/client/src/components/organization_vision/org_edit_vision/modal/EditOrgVision.styled.js
+++ b/client/src/components/organization_vision/org_edit_vision/modal/EditOrgVision.styled.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 export const EditVisionModal = styled(Dialog)`
   & .MuiDialog-paper {
     width: 100%;
-    border-radius: 10px;
+    border-radius: 0px;
     margin: 0;
     background-color: #f6f6f6;
   }
@@ -25,12 +25,13 @@ export const EditVisionModal = styled(Dialog)`
   }
   @media (min-width: 40.75rem) {
     & .MuiDialog-paper {
-      width: 42rem;
+      width: 720px;
     }
   }
 `;
 export const EditVisionContainer = styled.form`
-  padding: 2.53rem 2.42rem;
+  ${'' /* padding: 2.53rem 2.42rem; */}
+  padding: 35px;
 `;
 export const Header = styled.h2`
   text-align: center;
@@ -62,7 +63,9 @@ export const ActionButton = styled(Button)`
   background-color: rgba(0, 184, 124, 1);
   color: white;
   text-transform: capitalize;
-  padding: 0.33rem 2rem;
+  border-radius: 6px;
+  padding: 4px 45px;
+  font-weight: normal;
   &:hover {
     background-color: rgba(0, 184, 124, 1);
   }

--- a/client/src/components/organization_vision/org_edit_vision/modal/EditOrgVisionModal.jsx
+++ b/client/src/components/organization_vision/org_edit_vision/modal/EditOrgVisionModal.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Backdrop from '@material-ui/core/Backdrop';
 import Fade from '@material-ui/core/Fade';
 import { useSelector, useDispatch } from 'react-redux';
-import { updateOrgVision } from '../../../../redux/organizationVision.slice';
+import { updateOrgVision, showEditVisionModal } from '../../../../redux/organizationVision.slice';
 import {
   EditVisionModal,
   EditVisionContainer,
@@ -33,6 +33,7 @@ const OrganizationVisionEditModal = () => {
       aria-labelledby="organization-vision-modal"
       aria-describedby="edit-organization-vision-modal"
       open={showVisionModal}
+      onClose={() => dispatch(showEditVisionModal())}
       closeAfterTransition
       BackdropComponent={Backdrop}
       BackdropProps={{


### PR DESCRIPTION
Edit Mission and Edit Vision's design now look the same and as in the figma design.
Added close function to Edit Vision modal